### PR TITLE
Improve UI responsiveness.

### DIFF
--- a/inc/myevic.h
+++ b/inc/myevic.h
@@ -148,10 +148,11 @@ typedef struct
 /* 00200000 */	int fading:1;
 /* 00400000 */	int led_on:1;
 /* 00800000 */	int splash:1;
-				int autopuff:1;
-				int warmup:1;
-				int eco:1;
-				int animpwrbar:1;
+
+/* 01000000 */	int autopuff:1;
+/* 02000000 */	int warmup:1;
+/* 04000000 */	int eco:1;
+/* 08000000 */	int animpwrbar:1;
 }
 
 gFlags_t;

--- a/src/main.c
+++ b/src/main.c
@@ -999,10 +999,7 @@ __myevic__ void Main()
 			if ( ShowProfNum )
 				--ShowProfNum;
 
-			if ( !( gFlags.firing && ISMODETC(dfMode) ) )
-			{
-				DrawScreen();
-			}
+			DrawScreen();
 
 			if ( KeyTicks < 5 )
 			{
@@ -1061,14 +1058,7 @@ __myevic__ void Main()
 
 			gFlags.osc_1hz ^= 1;
 
-			if ( gFlags.firing )
-			{
-				if ( ISMODETC(dfMode) )
-				{
-					DrawScreen();
-				}
-			}
-			else
+			if ( !gFlags.firing )
 			{
 				if
 				(	!dfStatus.off

--- a/src/miscs.c
+++ b/src/miscs.c
@@ -825,7 +825,9 @@ __myevic__ void AnimPwrBar( int first )
 		tscaler = 0;
 	}
 
-	const int pwr = AtoPower( AtoVolts );
+	// Zero the bar when not firing, because Screen 2 remains visible
+	// for ~1 second after firing stops.
+	const int pwr = gFlags.firing ? AtoPower( AtoVolts ) : 0;
 	const int pwrmax = dfTCPower;
 
 	int bar = ( pwr * WIDTH / pwrmax );

--- a/src/screens.c
+++ b/src/screens.c
@@ -38,8 +38,7 @@ void SetScreen( int screen, int duration )
 
 
 //=========================================================================
-// Called at a frequency of 10Hz except when firing in TC modes.
-// Called at a frequency of 2Hz when firing in TC modes.
+// Called at a frequency of 10Hz
 
 __myevic__ void DrawScreen()
 {
@@ -51,7 +50,11 @@ __myevic__ void DrawScreen()
 		CurrentFD = FireDuration;
 		ScreenDuration = ISMODETC(dfMode) ? 1 : 3;
 		TenthOfSecs = 0;
-		gFlags.refresh_display = 1;
+		// Refresh at 2Hz in TC mode, or 10Hz otherwise.
+		if ( !ISMODETC(dfMode) || FireDuration % 5 == 1 )
+		{
+			gFlags.refresh_display = 1;
+		}
 	}
 	else if ( ScreenRefreshTimer && !--ScreenRefreshTimer )
 	{
@@ -225,16 +228,11 @@ __myevic__ void DrawScreen()
 		FadeOutTimer=0;
 		gFlags.fading=0;
 		Screen=2;
-		gFlags.refresh_display=1;
+		//gFlags.refresh_display=1;
 		return;
 	}
 
-	if (( gFlags.firing ) && ISMODETC(dfMode))
-		TenthOfSecs += 5;
-	else
-		TenthOfSecs += 1;
-
-	if ( TenthOfSecs < 10 )
+	if ( ++TenthOfSecs < 10 )
 		return;
 
 	TenthOfSecs = 0;


### PR DESCRIPTION
- Always call DrawScreen() at 10Hz, reducing the maximum fire button
  lag from 500ms to 100ms.  TC modes still refresh the screen at 2Hz,
  but this occurs at FireDuration=(1, 6, 11, ...) instead of following
  the global 2Hz clock.
- Immediately zero the power bar when firing stops.

One instance of 'refresh_display' was forcing warmup/autopuff mode to
refresh at 10Hz.  I didn't understand the purpose of this line, so I
left it commented out.